### PR TITLE
adding explode to split language-locale which fixes issue #2

### DIFF
--- a/src/ExpressionDescriptor.php
+++ b/src/ExpressionDescriptor.php
@@ -67,7 +67,8 @@ class ExpressionDescriptor
         list($second, $minute, $hour, $day, $month, $week, $year) = (new ExpressionParser($expression))->parse();
 
         $this->expression = compact('second', 'minute', 'hour', 'day', 'month', 'week', 'year');
-        $this->language = $language;
+        // $language variabel can also contain a locale but we only want the language Example: en-GB = en
+        $this->language = explode("-", $language)[0];
         $this->intl = extension_loaded('intl');
     }
 


### PR DESCRIPTION
[Locale Identifiers](https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a) (LCID) can contain a dash to denote language and location. Since ExpressionDescriptor.php expects just the language the location needs to be stripped off the end.